### PR TITLE
Allow baseURL to be configured

### DIFF
--- a/src/main/java/com/github/cleydyr/dart/system/io/factory/DartSassExecutableExtractorFactory.java
+++ b/src/main/java/com/github/cleydyr/dart/system/io/factory/DartSassExecutableExtractorFactory.java
@@ -3,10 +3,13 @@ package com.github.cleydyr.dart.system.io.factory;
 import com.github.cleydyr.dart.release.DartSassReleaseParameter;
 import com.github.cleydyr.dart.system.io.DartSassExecutableExtractor;
 import java.io.File;
+import java.net.URI;
+
 import org.apache.maven.settings.Proxy;
 
 public interface DartSassExecutableExtractorFactory {
 
     DartSassExecutableExtractor getDartSassExecutableExtractor(
+            URI baseURI,
             DartSassReleaseParameter dartSassReleaseParameter, File cachedFileDirectory, Proxy proxy);
 }

--- a/src/main/java/com/github/cleydyr/dart/system/io/factory/DefaultDartSassExecutableExtractorFactory.java
+++ b/src/main/java/com/github/cleydyr/dart/system/io/factory/DefaultDartSassExecutableExtractorFactory.java
@@ -12,6 +12,7 @@ import com.github.cleydyr.dart.system.io.ZipFilesystemExecutableResourcesProvide
 import com.github.cleydyr.dart.system.io.exception.DartSassExecutableExtractorException;
 import java.io.File;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -23,18 +24,21 @@ public class DefaultDartSassExecutableExtractorFactory implements DartSassExecut
 
     @Override
     public DartSassExecutableExtractor getDartSassExecutableExtractor(
+            URI baseURL,
             DartSassReleaseParameter dartSassReleaseParameter, File cachedFileDirectory, Proxy proxy) {
         try {
+            final ApacheFluidHttpClientReleaseDownloader downloader =
+                    new ApacheFluidHttpClientReleaseDownloader(baseURL, proxy);
             if (OSDetector.isWindows()) {
                 ExecutableResourcesProvider executableResourcesProvider;
                 executableResourcesProvider = new ZipFilesystemExecutableResourcesProvider(
-                        cachedFileDirectory, new ApacheFluidHttpClientReleaseDownloader(proxy));
+                        cachedFileDirectory, downloader);
 
                 return new WindowsDartSassExecutableExtractor(dartSassReleaseParameter, executableResourcesProvider);
             }
 
             ExecutableResourcesProvider executableResourcesProvider = new TarFilesystemExecutableResourcesProvider(
-                    cachedFileDirectory, new ApacheFluidHttpClientReleaseDownloader(proxy));
+                    cachedFileDirectory, downloader);
 
             return new PosixDartSassSnapshotExecutableExtractor(dartSassReleaseParameter, executableResourcesProvider);
         } catch (URISyntaxException | MalformedURLException e) {

--- a/src/main/java/com/github/cleydyr/maven/plugin/CompileSassMojo.java
+++ b/src/main/java/com/github/cleydyr/maven/plugin/CompileSassMojo.java
@@ -16,6 +16,7 @@ import com.github.cleydyr.dart.system.io.DefaultCachedFilesDirectoryProviderFact
 import com.github.cleydyr.dart.system.io.exception.DartSassExecutableExtractorException;
 import com.github.cleydyr.dart.system.io.factory.DartSassExecutableExtractorFactory;
 import java.io.File;
+import java.net.URI;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
@@ -281,6 +282,13 @@ public class CompileSassMojo extends AbstractMojo {
     @Parameter
     private File cachedFilesDirectory;
 
+    /**
+     * A base URL containing dart-sass releases.  The default is
+     * {@code https://github.com/sass/dart-sass/releases/download/}.
+     */
+    @Parameter
+    private URI baseURL = URI.create("https://github.com/sass/dart-sass/releases/download/");
+
     @Override
     public void execute() throws MojoExecutionException {
         validateProxyHostSyntax();
@@ -360,6 +368,7 @@ public class CompileSassMojo extends AbstractMojo {
     public void extractExecutable() throws MojoExecutionException {
         DartSassExecutableExtractor dartSassExecutableExtractor =
                 dartSassExecutableExtractorFactory.getDartSassExecutableExtractor(
+                        baseURL,
                         dartSassReleaseParameter, cachedFilesDirectory, proxy);
 
         try {

--- a/src/test/java/com/github/cleydyr/dart/maven/plugin/CompileSassMojoTest.java
+++ b/src/test/java/com/github/cleydyr/dart/maven/plugin/CompileSassMojoTest.java
@@ -18,7 +18,7 @@ public class CompileSassMojoTest extends TestCase {
         CompileSassMojo compileSassMojo = new CompileSassMojo(
                 new DefaultFileCounter(),
                 () -> null,
-                (any0, any1, any2) -> null,
+                (any0, any1, any2, any3) -> null,
                 new DummyGithubLatestVersionProvider(),
                 new OSDependentDefaultCachedFilesDirectoryProviderFactory(),
                 null);

--- a/src/test/java/com/github/cleydyr/dart/maven/plugin/WatchSassMojoTest.java
+++ b/src/test/java/com/github/cleydyr/dart/maven/plugin/WatchSassMojoTest.java
@@ -73,6 +73,6 @@ public class WatchSassMojoTest extends TestCase {
     }
 
     private DartSassExecutableExtractorFactory _mockDartSassExecutableExtractorFactory() {
-        return (any0, any1, any2) -> Mockito.mock(DartSassExecutableExtractor.class);
+        return (any0, any1, any2, any3) -> Mockito.mock(DartSassExecutableExtractor.class);
     }
 }


### PR DESCRIPTION
Allow configuration of the base URL for downloading dart-sass, so that private mirrors may be used in lieu of the public github.com.