### PR TITLE
update github actions and added example running on alpine

### DIFF
--- a/.github/workflows/java-ci-linux-musl.yaml
+++ b/.github/workflows/java-ci-linux-musl.yaml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'adopt'

--- a/.github/workflows/java-ci-linux.yaml
+++ b/.github/workflows/java-ci-linux.yaml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'adopt'

--- a/.github/workflows/java-ci-mac.yaml
+++ b/.github/workflows/java-ci-mac.yaml
@@ -7,9 +7,9 @@ jobs:
     runs-on: macos-12
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'adopt'

--- a/.github/workflows/java-ci-mac.yaml
+++ b/.github/workflows/java-ci-mac.yaml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/java-ci-windows.yaml
+++ b/.github/workflows/java-ci-windows.yaml
@@ -7,9 +7,9 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'adopt'

--- a/Dockerfile-test-alpine
+++ b/Dockerfile-test-alpine
@@ -1,8 +1,5 @@
 # Usa a imagem base do Alpine
-FROM alpine:latest
-
-# Instala o OpenJDK 8 e o Maven
-RUN apk add --no-cache openjdk11 maven
+FROM maven:3.9-eclipse-temurin-11-alpine
 
 # Copia os arquivos do diretório desejado para o container
 COPY ./ /dart-sass-maven-plugin

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ This parameter represents the Dart Sass operating system that should be used to 
 **Type**: String<br>
 **Required**: No
 
+> [!WARNING]
+> When compiling on alpine derived images, setting `os` to `linux-musl` is required as it cannot be autodetected.
+
 `<version>`
 
 This parameter represents the Dart Sass version that should be used to compile Sass files. If left unset, the version available at https://github.com/sass/dart-sass/releases/latest will be used.<br>


### PR DESCRIPTION
updated github actions to v4

- using macos-13 for the `Java CI on Mac` (curious if m1 / arm64 would impact)
- using maven:3.9-eclipse-temurin-11-alpine base image for `Java CI on Linux Alpine`

not copying  pom from `musl/test-project` as proof of concept

that seems to indicate that setting `<os>linux-musl</os>` is required for running on alpine images, should that be auto-detected or is it by-design?